### PR TITLE
Update KaTeX and Github stylesheets to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ let result = md.render('# Math Rulez! \n  $\\sqrt{3x-1}+(1+x)^2$');
 Include the KaTeX stylesheet in your html:
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.11.1/katex.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.16.8/katex.min.css">
 ```
 
 If you're using the default markdown-it parser, I also recommend the [github stylesheet](https://github.com/sindresorhus/github-markdown-css):
 
 ```html
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/4.0.0/github-markdown.min.css"/>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/5.2.0/github-markdown.min.css"/>
 ```
 
 `KaTeX` options can be supplied with the second argument to use.


### PR DESCRIPTION
Latest version of KaTeX (0.16.8)
Source: https://katex.org/en/versions.html

Latest version of Github Markdown CSS (5.2.0)
Source: https://github.com/sindresorhus/github-markdown-css/releases/tag/v5.2.0